### PR TITLE
chore: Update golangci-lint version in CI workflow from v1.61.0 to v1.63.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           
       - name: Run Go linter


### PR DESCRIPTION
This pull request updates the version of `golangci-lint` used in the GitHub Actions workflow for linting Go code.

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L47-R47): Updated `golangci-lint` installation script to use version `v1.63.4` instead of `v1.61.0`.